### PR TITLE
fix: 管理者画面の入力フィールドの文字色を黒に修正

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -312,7 +312,7 @@ export default function AdminPage() {
                 value={formData.title}
                 onChange={handleInputChange}
                 required
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none text-gray-900"
                 placeholder="例: 7つの習慣"
               />
             </div>
@@ -329,7 +329,7 @@ export default function AdminPage() {
                 value={formData.amazon_url}
                 onChange={handleInputChange}
                 required
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none text-gray-900"
                 placeholder="https://amazon.co.jp/dp/..."
               />
               <p className="text-xs text-gray-500 mt-1">
@@ -349,7 +349,7 @@ export default function AdminPage() {
                 value={formData.x_post_url}
                 onChange={handleInputChange}
                 required
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none text-gray-900"
                 placeholder="https://x.com/username/status/1234567890"
               />
               <p className="text-xs text-gray-500 mt-1">


### PR DESCRIPTION
## 概要
スマホで管理者画面から書籍を登録する際に、入力した文字色が薄い問題を修正しました。

## 修正内容
- 書籍名、Amazonリンク、Xポストリンクの入力フィールドに  クラスを追加
- 入力文字の視認性を向上

## 変更ファイル
- `src/app/admin/page.tsx`

## テスト
- [x] リンターエラーなし
- [x] 3つの入力フィールドすべてに修正適用

## 関連issue
スマホでの入力文字色の問題を解決